### PR TITLE
Add ERC-1155 WLDHUBItems contract with tests (#8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ To run tests, run the following command
 ```bash
   forge test --match-path test/TimeLockedVault.t.sol
 ```
+To run test - WLDHubItems.t.sol below command is used
+
+```bash
+  forge test --match-path test/WLDHubItems.t.sol 
+```
 
 Ensure your .env is set up with RPC URL and private key if needed.
 ## 📁 Files:

--- a/src/WLDHubItems.sol
+++ b/src/WLDHubItems.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {ERC1155} from "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+import {ERC1155Burnable} from "@openzeppelin/contracts/token/ERC1155/extensions/ERC1155Burnable.sol";
+import {ERC1155Pausable} from "@openzeppelin/contracts/token/ERC1155/extensions/ERC1155Pausable.sol";
+import {ERC1155Supply} from "@openzeppelin/contracts/token/ERC1155/extensions/ERC1155Supply.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+contract WLDHUBItems is ERC1155, Ownable, ERC1155Pausable, ERC1155Burnable, ERC1155Supply {
+    /// @dev Thrown when an invalid (zero) address is provided.
+    error InvalidAddress();
+
+    /// @dev Thrown when array lengths do not match.
+    error InvalidArrayLength();
+
+    /// @notice Mapping to store individual URIs for each token ID.
+    mapping(uint256 => string) private _tokenURIs;
+
+    /// @notice Emitted when a token is minted.
+    event TokenMinted(address indexed to, uint256 indexed id, uint256 amount);
+
+    /// @notice Emitted when multiple tokens are minted in a batch.
+    event TokenBatchMinted(address indexed to, uint256[] ids, uint256[] amounts);
+
+    /**
+     * @notice Initializes the contract and sets the owner.
+     * @param initialOwner Address to be set as the initial contract owner.
+     */
+    constructor(address initialOwner) ERC1155("") Ownable(initialOwner) {
+        if (initialOwner == address(0)) revert InvalidAddress();
+    }
+
+    /**
+     * @notice Sets a custom URI for a given token ID.
+     * @dev Only callable by the owner.
+     * @param id Token ID to set the URI for.
+     * @param newuri The new URI to assign to the token ID.
+     */
+    function setURI(uint256 id, string memory newuri) public onlyOwner {
+        _tokenURIs[id] = newuri;
+    }
+
+    /**
+     * @notice Returns the URI for a given token ID.
+     * @param id Token ID to query.
+     * @return The metadata URI for the token.
+     */
+    function uri(uint256 id) public view override returns (string memory) {
+        return _tokenURIs[id];
+    }
+
+    /**
+     * @notice Pauses all token transfers.
+     * @dev Only callable by the owner.
+     */
+    function pause() public onlyOwner {
+        _pause();
+    }
+
+    /**
+     * @notice Unpauses all token transfers.
+     * @dev Only callable by the owner.
+     */
+    function unpause() public onlyOwner {
+        _unpause();
+    }
+
+    /**
+     * @notice Mints a specific amount of a token to a given address.
+     * @dev Only callable by the owner.
+     * @param account Address to mint the token to.
+     * @param id Token ID to mint.
+     * @param amount Amount of tokens to mint.
+     * @param data Additional data passed to the receiver.
+     */
+    function mint(address account, uint256 id, uint256 amount, bytes memory data) public onlyOwner {
+        if (account == address(0)) revert InvalidAddress();
+        _mint(account, id, amount, data);
+        emit TokenMinted(account, id, amount);
+    }
+
+    /**
+     * @notice Mints multiple token types in a batch to a given address.
+     * @dev Only callable by the owner.
+     * @param to Address to mint the tokens to.
+     * @param ids List of token IDs to mint.
+     * @param amounts Corresponding list of amounts to mint for each token ID.
+     * @param data Additional data passed to the receiver.
+     */
+    function mintBatch(address to, uint256[] memory ids, uint256[] memory amounts, bytes memory data)
+        public
+        onlyOwner
+    {
+        if (to == address(0)) revert InvalidAddress();
+        if (ids.length != amounts.length) revert InvalidArrayLength();
+
+        _mintBatch(to, ids, amounts, data);
+        emit TokenBatchMinted(to, ids, amounts);
+    }
+
+    /**
+     * @dev Internal hook called before any token transfer, mint, or burn.
+     * @param from Address transferring from.
+     * @param to Address transferring to.
+     * @param ids List of token IDs being transferred.
+     * @param values List of token amounts being transferred.
+     */
+    function _update(address from, address to, uint256[] memory ids, uint256[] memory values)
+        internal
+        override(ERC1155, ERC1155Pausable, ERC1155Supply)
+    {
+        super._update(from, to, ids, values);
+    }
+}

--- a/src/WLDHubItems.sol
+++ b/src/WLDHubItems.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
 import {ERC1155} from "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";

--- a/test/WLDHubItems.t.sol
+++ b/test/WLDHubItems.t.sol
@@ -1,0 +1,340 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Test, console} from "forge-std/Test.sol";
+import {WLDHUBItems} from "../src/WLDHubItems.sol";
+import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
+
+contract MockERC1155Receiver is IERC1155Receiver {
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata)
+        external
+        pure
+        override
+        returns (bytes4)
+    {
+        return this.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata)
+        external
+        pure
+        override
+        returns (bytes4)
+    {
+        return this.onERC1155BatchReceived.selector;
+    }
+
+    function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
+        return interfaceId == type(IERC1155Receiver).interfaceId;
+    }
+}
+
+contract WLDHUBItemsTest is Test {
+    WLDHUBItems public token;
+    MockERC1155Receiver public receiver;
+    address public owner;
+    address public user1;
+    address public user2;
+
+    // Events to test
+    event TokenMinted(address indexed to, uint256 indexed id, uint256 amount);
+    event TokenBatchMinted(address indexed to, uint256[] ids, uint256[] amounts);
+
+    function setUp() public {
+        owner = address(this);
+        user1 = address(0x1);
+        user2 = address(0x2);
+
+        token = new WLDHUBItems(owner);
+        receiver = new MockERC1155Receiver();
+    }
+
+    function testConstructor() public {
+        assertEq(token.owner(), owner);
+        assertFalse(token.paused());
+    }
+
+    function testSetURI() public {
+        uint256 tokenId = 1;
+        string memory newURI = "https://example.com/token/1";
+
+        token.setURI(tokenId, newURI);
+        assertEq(token.uri(tokenId), newURI);
+    }
+
+    function testSetURIOnlyOwner() public {
+        vm.prank(user1);
+        vm.expectRevert();
+        token.setURI(1, "https://example.com/token/1");
+    }
+
+    function testMint() public {
+        uint256 tokenId = 1;
+        uint256 amount = 100;
+
+        vm.expectEmit(true, true, true, true);
+        emit TokenMinted(user1, tokenId, amount);
+
+        token.mint(user1, tokenId, amount, "");
+
+        assertEq(token.balanceOf(user1, tokenId), amount);
+        assertEq(token.totalSupply(tokenId), amount);
+        assertTrue(token.exists(tokenId));
+    }
+
+    function testMintToZeroAddress() public {
+        vm.expectRevert(WLDHUBItems.InvalidAddress.selector);
+        token.mint(address(0), 1, 100, "");
+    }
+
+    function testMintOnlyOwner() public {
+        vm.prank(user1);
+        vm.expectRevert();
+        token.mint(user2, 1, 100, "");
+    }
+
+    function testMintBatch() public {
+        uint256[] memory ids = new uint256[](3);
+        uint256[] memory amounts = new uint256[](3);
+
+        ids[0] = 1;
+        ids[1] = 2;
+        ids[2] = 3;
+        amounts[0] = 100;
+        amounts[1] = 200;
+        amounts[2] = 300;
+
+        vm.expectEmit(true, true, true, true);
+        emit TokenBatchMinted(user1, ids, amounts);
+
+        token.mintBatch(user1, ids, amounts, "");
+
+        uint256[] memory balances = token.balanceOfBatch(_buildAddressArray(user1, 3), ids);
+
+        assertEq(balances[0], amounts[0]);
+        assertEq(balances[1], amounts[1]);
+        assertEq(balances[2], amounts[2]);
+
+        assertEq(token.totalSupply(1), 100);
+        assertEq(token.totalSupply(2), 200);
+        assertEq(token.totalSupply(3), 300);
+    }
+
+    function testMintBatchToZeroAddress() public {
+        uint256[] memory ids = new uint256[](1);
+        uint256[] memory amounts = new uint256[](1);
+        ids[0] = 1;
+        amounts[0] = 100;
+
+        vm.expectRevert(WLDHUBItems.InvalidAddress.selector);
+        token.mintBatch(address(0), ids, amounts, "");
+    }
+
+    function testMintBatchArrayLengthMismatch() public {
+        uint256[] memory ids = new uint256[](2);
+        uint256[] memory amounts = new uint256[](1);
+        ids[0] = 1;
+        ids[1] = 2;
+        amounts[0] = 100;
+
+        vm.expectRevert(WLDHUBItems.InvalidArrayLength.selector);
+        token.mintBatch(user1, ids, amounts, "");
+    }
+
+    function testMintBatchOnlyOwner() public {
+        uint256[] memory ids = new uint256[](1);
+        uint256[] memory amounts = new uint256[](1);
+        ids[0] = 1;
+        amounts[0] = 100;
+
+        vm.prank(user1);
+        vm.expectRevert();
+        token.mintBatch(user2, ids, amounts, "");
+    }
+
+    function testPause() public {
+        token.pause();
+        assertTrue(token.paused());
+    }
+
+    function testPauseOnlyOwner() public {
+        vm.prank(user1);
+        vm.expectRevert();
+        token.pause();
+    }
+
+    function testUnpause() public {
+        token.pause();
+        assertTrue(token.paused());
+
+        token.unpause();
+        assertFalse(token.paused());
+    }
+
+    function testUnpauseOnlyOwner() public {
+        token.pause();
+
+        vm.prank(user1);
+        vm.expectRevert();
+        token.unpause();
+    }
+
+    function testTransferWhenPaused() public {
+        // First mint some tokens
+        token.mint(user1, 1, 100, "");
+
+        // Pause the contract
+        token.pause();
+
+        // Try to transfer - should fail
+        vm.prank(user1);
+        vm.expectRevert();
+        token.safeTransferFrom(user1, user2, 1, 50, "");
+    }
+
+    function testBurn() public {
+        uint256 tokenId = 1;
+        uint256 mintAmount = 100;
+        uint256 burnAmount = 30;
+
+        // Mint tokens first
+        token.mint(user1, tokenId, mintAmount, "");
+
+        // Burn tokens
+        vm.prank(user1);
+        token.burn(user1, tokenId, burnAmount);
+
+        assertEq(token.balanceOf(user1, tokenId), mintAmount - burnAmount);
+        assertEq(token.totalSupply(tokenId), mintAmount - burnAmount);
+    }
+
+    function testBurnBatch() public {
+        uint256[] memory ids = new uint256[](2);
+        uint256[] memory mintAmounts = new uint256[](2);
+        uint256[] memory burnAmounts = new uint256[](2);
+
+        ids[0] = 1;
+        ids[1] = 2;
+        mintAmounts[0] = 100;
+        mintAmounts[1] = 200;
+        burnAmounts[0] = 30;
+        burnAmounts[1] = 50;
+
+        // Mint tokens first
+        token.mintBatch(user1, ids, mintAmounts, "");
+
+        // Burn tokens
+        vm.prank(user1);
+        token.burnBatch(user1, ids, burnAmounts);
+
+        assertEq(token.balanceOf(user1, 1), 70);
+        assertEq(token.balanceOf(user1, 2), 150);
+        assertEq(token.totalSupply(1), 70);
+        assertEq(token.totalSupply(2), 150);
+    }
+
+    function testSupportsInterface() public {
+        // Test ERC1155 interface
+        assertTrue(token.supportsInterface(0xd9b67a26));
+        // Test ERC165 interface
+        assertTrue(token.supportsInterface(0x01ffc9a7));
+    }
+
+    function testSafeTransferFrom() public {
+        uint256 tokenId = 1;
+        uint256 amount = 100;
+        uint256 transferAmount = 30;
+
+        // Mint tokens
+        token.mint(user1, tokenId, amount, "");
+
+        // Transfer tokens
+        vm.prank(user1);
+        token.safeTransferFrom(user1, user2, tokenId, transferAmount, "");
+
+        assertEq(token.balanceOf(user1, tokenId), amount - transferAmount);
+        assertEq(token.balanceOf(user2, tokenId), transferAmount);
+    }
+
+    function testSafeBatchTransferFrom() public {
+        uint256[] memory ids = new uint256[](2);
+        uint256[] memory amounts = new uint256[](2);
+        uint256[] memory transferAmounts = new uint256[](2);
+
+        ids[0] = 1;
+        ids[1] = 2;
+        amounts[0] = 100;
+        amounts[1] = 200;
+        transferAmounts[0] = 30;
+        transferAmounts[1] = 50;
+
+        // Mint tokens
+        token.mintBatch(user1, ids, amounts, "");
+
+        // Transfer tokens
+        vm.prank(user1);
+        token.safeBatchTransferFrom(user1, user2, ids, transferAmounts, "");
+
+        assertEq(token.balanceOf(user1, 1), 70);
+        assertEq(token.balanceOf(user1, 2), 150);
+        assertEq(token.balanceOf(user2, 1), 30);
+        assertEq(token.balanceOf(user2, 2), 50);
+    }
+
+    function testSetApprovalForAll() public {
+        vm.prank(user1);
+        token.setApprovalForAll(user2, true);
+
+        assertTrue(token.isApprovedForAll(user1, user2));
+
+        vm.prank(user1);
+        token.setApprovalForAll(user2, false);
+
+        assertFalse(token.isApprovedForAll(user1, user2));
+    }
+
+    function testMintWithData() public {
+        bytes memory data = "test data";
+        token.mint(address(receiver), 1, 100, data);
+
+        assertEq(token.balanceOf(address(receiver), 1), 100);
+    }
+
+    function testMintBatchWithData() public {
+        uint256[] memory ids = new uint256[](2);
+        uint256[] memory amounts = new uint256[](2);
+        ids[0] = 1;
+        ids[1] = 2;
+        amounts[0] = 100;
+        amounts[1] = 200;
+
+        bytes memory data = "batch test data";
+        token.mintBatch(address(receiver), ids, amounts, data);
+
+        assertEq(token.balanceOf(address(receiver), 1), 100);
+        assertEq(token.balanceOf(address(receiver), 2), 200);
+    }
+
+    // Helper function to build address array for balanceOfBatch
+    function _buildAddressArray(address addr, uint256 length) internal pure returns (address[] memory) {
+        address[] memory addresses = new address[](length);
+        for (uint256 i = 0; i < length; i++) {
+            addresses[i] = addr;
+        }
+        return addresses;
+    }
+
+    // Fuzz testing
+    function testFuzzMint(address to, uint256 id, uint256 amount) public {
+        vm.assume(to != address(0));
+        vm.assume(amount > 0 && amount < type(uint128).max);
+
+        token.mint(to, id, amount, "");
+        assertEq(token.balanceOf(to, id), amount);
+    }
+
+    function testFuzzSetURI(uint256 id, string memory newURI) public {
+        token.setURI(id, newURI);
+        assertEq(token.uri(id), newURI);
+    }
+}

--- a/test/WLDHubItems.t.sol
+++ b/test/WLDHubItems.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
 import {Test, console} from "forge-std/Test.sol";


### PR DESCRIPTION
Implement ERC-1155 Token Contract for WLD HUB Items (#8): 

Added WLDHUBItems contract with support for multiple token types (badges, credits, access passes), and included complete Foundry test suite covering minting, burning, transfers, approvals, pausing, and fuzz tests. Prioritized security and gas efficiency.